### PR TITLE
Multiple fixes in HTTPServer.py

### DIFF
--- a/src/servers/HTTPServer.py
+++ b/src/servers/HTTPServer.py
@@ -1,12 +1,14 @@
+"""HTTP Server"""
 import http.client
 import http.server
 import socketserver
-from src.utils.arguments import *
+import src.utils.arguments
 from src.configs import config
 from src.utils import colors
 
 
 class ServerHandler(http.server.SimpleHTTPRequestHandler):
+    """HTTP Server Handler"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=config.webDir, **kwargs)
 
@@ -15,10 +17,11 @@ class ServerHandler(http.server.SimpleHTTPRequestHandler):
 
 
 def serve_forever():
+    """Serve Forever"""
     socketserver.TCPServer.allow_reuse_address = True
     try:
         with socketserver.TCPServer(("", config.rfi_test_port), ServerHandler) as httpd:
-            if args.verbose:
+            if src.utils.arguments.args.verbose:
                 print(
                     colors.blue("[i]")
                     + " Opening temporary local web server on port "
@@ -30,7 +33,7 @@ def serve_forever():
             except:
                 httpd.server_close()
     except:
-        if args.verbose:
+        if src.utils.arguments.args.verbose:
             print(
                 colors.red("[-]")
                 + " Cannot setup local web server on port "


### PR DESCRIPTION
1. Use src.utils.arguments import rather than args, to avoid confusion inside ServerHandler
2. docstring